### PR TITLE
changes to title page format

### DIFF
--- a/thesis.cls
+++ b/thesis.cls
@@ -358,12 +358,12 @@
 \newcommand{\ttlpage}{
      \thispagestyle{empty}
      \begin{center}
-         \textsc{\large \title}
+         \title
          \vspace{\baselineskip}
 
-         \textit{by}
+         By
 
-         \textsc{\author}
+         \author
          \vspace{\baselineskip}
 
          A dissertation submitted in partial fulfillment of
@@ -371,14 +371,14 @@
          the requirements for the degree of
          \vspace{\baselineskip}
 
-         \textsc{Doctor of Philosophy}
+         Doctor of Philosophy
 
-         \textsc{(Astronomy)}
+         (Astronomy)
          \vspace{\baselineskip}
 
-         \textit{at the}
+         at the
 
-         \textsc{University of Wisconsin--Madison}
+         UNIVERSITY OF WISCONSIN--MADISON
 
          {\year}
      \end{center}
@@ -397,7 +397,7 @@
          \@committeetwo\\
          \@committeethree\\
          \@committeefour\\
-         \@committeefive
+        % \@committeefive
      \end{minipage}
 %     \indent \@committeesix 
 


### PR DESCRIPTION
Changed some minor title page formatting to match the example given by the graduate school. See the guides: https://grad.wisc.edu/current-students/doctoral-guide/ and in particular the example here: https://grad.wiscweb.wisc.edu/wp-content/uploads/sites/329/2017/11/new_phd_title_page.pdf

Note: I talked to a non-astro student who had trouble with the formatting of his title page, but also heard from the grad school that the formatting generally doesn't matter as long as the content is ok. 
 